### PR TITLE
Switch to Zephyr toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-# Base image which contains global dependencies
 FROM ubuntu:20.04 as base
 WORKDIR /workdir
 
-# System dependencies
 ARG arch=amd64
+ARG zephyr_toolchain_release=0.14.2
+
+# System dependencies
 RUN mkdir /workdir/project && \
     mkdir /workdir/.cache && \
     apt-get -y update && \
@@ -22,36 +23,9 @@ RUN mkdir /workdir/project && \
         device-tree-compiler=1.5.1-1 \
         ruby && \
     apt-get -y clean && apt-get -y autoremove && \
-    # GCC ARM Embed Toolchain
-    echo "Target architecture: $arch" && \
-    case $arch in \
-        "amd64") \
-            NCLT_URL="https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-15-0/nrf-command-line-tools-10.15.0_amd.zip" \
-            ARM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D" \
-            ;; \
-        "arm64") \
-            NCLT_URL="" \
-            ARM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2?revision=4583ce78-e7e7-459a-ad9f-bff8e94839f1&hash=CF9005177C5564B8A88F71AF541808EB" \
-            ;; \
-        *) \
-            echo "Unsupported TARGETARCH: \"$TARGETARCH\"" >&2 && \
-            exit 1 ;; \
-    esac && \
-    wget -qO - "${ARM_URL}" | tar xj && \
-    # Nordic command line tools
-    # Releases: https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
-    # Doesn't exist for arm64, but not necessary for building
-    if [ ! -z "$NCLT_URL" ]; then \
-        mkdir tmp && cd tmp && \
-        wget -q "${NCLT_URL}" && \
-        unzip nrf-command-line-tools-*.zip && \
-        tar xzf nrf-command-line-tools-*.tar.gz && \
-        dpkg -i *.deb && \
-        cd .. && rm -rf tmp ; \
-    else \
-        echo "Skipping nRF Command Line Tools (not available for $arch)" ; \
-    fi && \
+    #
     # Latest PIP & Python dependencies
+    #
     python3 -m pip install -U pip && \
     python3 -m pip install -U setuptools && \
     python3 -m pip install cmake>=3.20.0 wheel && \
@@ -60,11 +34,51 @@ RUN mkdir /workdir/project && \
     python3 -m pip install pc_ble_driver_py && \
     # Newer PIP will not overwrite distutils, so upgrade PyYAML manually
     python3 -m pip install --ignore-installed -U PyYAML && \
+    #
     # ClangFormat
+    #
     python3 -m pip install -U six && \
     apt-get -y install clang-format-9 && \
     ln -s /usr/bin/clang-format-9 /usr/bin/clang-format && \
-    wget -qO- https://raw.githubusercontent.com/nrfconnect/sdk-nrf/main/.clang-format > /workdir/.clang-format
+    wget -qO- https://raw.githubusercontent.com/nrfconnect/sdk-nrf/main/.clang-format > /workdir/.clang-format && \
+    #
+    # Nordic command line tools
+    #
+    echo "Target architecture: $arch" && \
+    case $arch in \
+        "amd64") \
+            NCLT_URL="https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-16-0/nrf-command-line-tools-10.16.0_Linux-amd64.tar.gz" \
+            ;; \
+        "arm64") \
+            NCLT_URL="https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-16-0/nrf-command-line-tools-10.16.0_Linux-arm64.tar.gz" \
+            ;; \
+    esac && \
+    # Releases: https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
+    if [ ! -z "$NCLT_URL" ]; then \
+        mkdir tmp && cd tmp && \
+        wget -qO - "${NCLT_URL}" | tar xz && \
+        DEBIAN_FRONTEND=noninteractive apt-get -y install ./*.deb && \
+        cd .. && rm -rf tmp ; \
+    else \
+        echo "Skipping nRF Command Line Tools (not available for $arch)" ; \
+    fi && \
+    #
+    # Zephyr Toolchain
+    #
+    echo "Target architecture: $arch" && \
+    case $arch in \
+        "amd64") \
+            ZEPHYR_TOOLCHAIN_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${zephyr_toolchain_release}/zephyr-sdk-${zephyr_toolchain_release}_linux-x86_64.tar.gz" \
+            ;; \
+        "arm64") \
+            ZEPHYR_TOOLCHAIN_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${zephyr_toolchain_release}/zephyr-sdk-${zephyr_toolchain_release}_linux-aarch64.tar.gz" \
+            ;; \
+        *) \
+            echo "Unsupported target architecture: \"$arch\"" >&2 && \
+            exit 1 ;; \
+    esac && \
+    wget -qO - "${ZEPHYR_TOOLCHAIN_URL}" | tar xz && \
+    cd /workdir/zephyr-sdk-${zephyr_toolchain_release} && yes | ./setup.sh
 
 # Download sdk-nrf and west dependencies to install pip requirements
 FROM base
@@ -82,8 +96,7 @@ WORKDIR /workdir/project
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV XDG_CACHE_HOME=/workdir/.cache
-ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-ENV GNUARMEMB_TOOLCHAIN_PATH=/workdir/gcc-arm-none-eabi-9-2019-q4-major
+ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+ENV ZEPHYR_SDK_INSTALL_DIR=/workdir/zephyr-sdk-${zephyr_toolchain_release}
 ENV ZEPHYR_BASE=/workdir/project/zephyr
-ENV PATH="${GNUARMEMB_TOOLCHAIN_PATH}/bin:${PATH}"
 ENV PATH="${ZEPHYR_BASE}/scripts:${PATH}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Building nRF Connect SDK applications with Docker
+# Docker image for building nRF Connect SDK applications
 
 ![Publish Docker](https://github.com/NordicPlayground/nrf-docker/workflows/Publish%20Docker/badge.svg?branch=saga)
 (_the [Docker image](https://hub.docker.com/r/nordicplayground/nrfconnect-sdk) is build against [nRF Connect SDK](https://github.com/nrfconnect/sdk-nrf) `main`,`v2.0-branch`,`v1.9-branch`,`v1.8-branch`, `v1.7-branch`, `v1.6-branch`, `v1.5-branch`, and `v1.4-branch` every night._)


### PR DESCRIPTION
Since nRF Connect SDK 2.0.0 the Zephyr toolchain is used.

See https://docs.zephyrproject.org/latest/develop/toolchains/zephyr_sdk.html#install-zephyr-sdk-on-linux