### PR TITLE
fix: install nrfjprog

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -78,6 +78,10 @@ jobs:
         run: |
           docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} nrfutil
 
+      - name: Ensure nrfjprog works
+        run: |
+          docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} nrfjprog -v
+
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -72,3 +72,7 @@ jobs:
       - name: Ensure nrfutil works
         run: |
           docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} nrfutil
+
+      - name: Ensure nrfjprog works
+        run: |
+          docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} nrfjprog -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,12 @@ RUN mkdir /workdir/project && \
     if [ ! -z "$NCLT_URL" ]; then \
         mkdir tmp && cd tmp && \
         wget -qO - "${NCLT_URL}" | tar xz && \
+        # Install included JLink
         DEBIAN_FRONTEND=noninteractive apt-get -y install ./*.deb && \
+        # Install nrf-command-line-tools
+        cp -r ./nrf-command-line-tools /opt && \
+        ln -s /opt/nrf-command-line-tools/bin/nrfjprog /usr/local/bin/nrfjprog && \
+        ln -s /opt/nrf-command-line-tools/bin/mergehex /usr/local/bin/mergehex && \
         cd .. && rm -rf tmp ; \
     else \
         echo "Skipping nRF Command Line Tools (not available for $arch)" ; \

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ This builds the `hci_uart` sample and stores the `hci_uart.hex` file in the curr
     # assumes asset_tracker_v2 built already (see above)
     docker run --rm -v ${PWD}:/workdir/project \
         -w /workdir/project/nrf/applications/asset_tracker_v2 \
-        nrfconnect-sdk \
         --device=/dev/ttyACM0 --privileged \
         nrfconnect-sdk \
         west flash


### PR DESCRIPTION
The current definition only installed the
JLink distribution, but did not install
nrjfprog