### PR TITLE
Install nrfutil with its dependencies isolated

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -76,8 +76,6 @@ jobs:
             nrf/applications/asset_tracker_v2/build/zephyr/app_update.bin
 
       - name: Ensure nrfutil works
-        # nrfutil does not work on main and v2.1 currently: https://github.com/NordicPlayground/nrf-docker/issues/20
-        if: matrix.ncs_branch != 'main' && matrix.ncs_branch != 'v2.1-branch'
         run: |
           docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} nrfutil
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -71,8 +71,6 @@ jobs:
             nrf/applications/asset_tracker_v2/build/zephyr/app_update.bin
 
       - name: Ensure nrfutil works
-        # nrfutil does not work on main and v2.1 currently: https://github.com/NordicPlayground/nrf-docker/issues/20
-        if: matrix.ncs_branch != 'main' && matrix.ncs_branch != 'v2.1-branch'
         run: |
           docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} nrfutil
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir /workdir/project && \
     apt-get -y install \
         wget \
         python3-pip \
+        python3-venv \
         ninja-build \
         gperf \
         git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN mkdir /workdir/project && \
     #
     # Isolated command line tools
     #
-    pipx install nrfutil && \
+    PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
+        pipx install nrfutil && \
     #
     # ClangFormat
     #

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,17 @@ RUN mkdir /workdir/project && \
     # Latest PIP & Python dependencies
     #
     python3 -m pip install -U pip && \
+    python3 -m pip install -U pipx && \
     python3 -m pip install -U setuptools && \
     python3 -m pip install 'cmake>=3.20.0' wheel && \
     python3 -m pip install -U 'west==0.14.0' && \
-    python3 -m pip install -U nrfutil && \
-    # Downgrade protobuf manually until nrfutil's fix is released: https://github.com/NordicSemiconductor/pc-nrfutil/commit/c03b0dca945f38d8095dc71894b81dfbfd1dca7f
-    python3 -m pip install -U 'protobuf<4.0.0' && \
     python3 -m pip install pc_ble_driver_py && \
     # Newer PIP will not overwrite distutils, so upgrade PyYAML manually
     python3 -m pip install --ignore-installed -U PyYAML && \
+    #
+    # Isolated command line tools
+    #
+    pipx install nrfutil && \
     #
     # ClangFormat
     #


### PR DESCRIPTION
I think this takes care of https://github.com/NordicPlayground/nrf-docker/issues/20.

I tested with the following:

```bash
docker build -t nrfconnect-sdk --build-arg sdk_nrf_revision=v2.1-branch .
```

```bash
docker run --rm -it nrfconnect-sdk bash

root@1ea371030882:/workdir/project# pip freeze | grep protobuf
protobuf==4.21.7

root@1ea371030882:/workdir/project# nrfutil --help
Usage: nrfutil [OPTIONS] COMMAND [ARGS]...

Options:
  -v, --verbose            Increase verbosity of output. Can be specified more
                           than once (up to -v -v -v -v).
  -o, --output <filename>  Log output to file
  --help                   Show this message and exit.

Commands:
  dfu       Perform a Device Firmware Update over serial, BLE, Thread, Zigbee
            or ANT transport given a DFU package (zip file).
  keys      Generate and display private and public keys.
  pkg       Display or generate a DFU package (zip file).
  settings  Generate and display Bootloader DFU settings.
  version   Display nrfutil version.
  zigbee    Zigbee-related commands and utilities.

root@1ea371030882:/workdir/project# PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx list
venvs are in /opt/pipx/venvs
apps are exposed on your $PATH at /usr/local/bin
   package nrfutil 6.1.7, installed using Python 3.8.10
    - nrfutil

root@1ea371030882:/workdir/project# ls /opt/pipx/venvs/nrfutil/lib/python3.8/site-packages/ | grep proto
protobuf-3.20.3-py3.8-nspkg.pth
protobuf-3.20.3.dist-info
```

So the correct (higher version) of protobuf is installed for Zephyr and nrfutil works fine with it's own 3.20.3 version.