### PR TITLE
Ignore absurd UID and GID values in nRF tools archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN mkdir /workdir/project && \
     # Releases: https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
     if [ ! -z "$NCLT_URL" ]; then \
         mkdir tmp && cd tmp && \
-        wget -qO - "${NCLT_URL}" | tar xz && \
+        wget -qO - "${NCLT_URL}" | tar --no-same-owner -xz && \
         # Install included JLink
         DEBIAN_FRONTEND=noninteractive apt-get -y install ./*.deb && \
         # Install nrf-command-line-tools


### PR DESCRIPTION
Building the container with rootless podman fails because the nRF command line tools tar archive has absurd UID and GID values. The easy fix is to ignore them.