### PR TITLE
No nrfutil on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,13 @@ RUN mkdir /workdir/project && \
     # Isolated command line tools
     # No nrfutil 6+ release for arm64 (M1/M2 Macs), yet: https://github.com/NordicSemiconductor/pc-ble-driver-py/issues/227
     #
-    PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin && \
     case $arch in \
     "amd64") \
+        PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
         pipx install 'nrfutil>=6.0.0' \
         ;; \
     "arm64") \
+        PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
         pipx install 'nrfutil<6.0.0' \
         ;; \
     esac && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,16 +35,12 @@ RUN mkdir /workdir/project && \
     python3 -m pip install --ignore-installed -U PyYAML && \
     #
     # Isolated command line tools
-    # No nrfutil 6+ release for arm64 (M1/M2 Macs), yet: https://github.com/NordicSemiconductor/pc-ble-driver-py/issues/227
+    # No nrfutil 6+ release for arm64 (M1/M2 Macs) and Python 3, yet: https://github.com/NordicSemiconductor/pc-ble-driver-py/issues/227
     #
     case $arch in \
     "amd64") \
         PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
         pipx install 'nrfutil>=6.0.0' \
-        ;; \
-    "arm64") \
-        PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
-        pipx install 'nrfutil<6.0.0' \
         ;; \
     esac && \
     #

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,17 @@ RUN mkdir /workdir/project && \
     python3 -m pip install --ignore-installed -U PyYAML && \
     #
     # Isolated command line tools
+    # No nrfutil 6+ release for arm64 (M1/M2 Macs), yet: https://github.com/NordicSemiconductor/pc-ble-driver-py/issues/227
     #
-    PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
-        pipx install 'nrfutil>=6.0.0' && \
+    PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin && \
+    case $arch in \
+    "amd64") \
+        pipx install 'nrfutil>=6.0.0' \
+        ;; \
+    "arm64") \
+        pipx install 'nrfutil<6.0.0' \
+        ;; \
+    esac && \
     #
     # ClangFormat
     #


### PR DESCRIPTION
Disable nrfutil on arm64 (e.g. Apple M1/M2 Silicon) because it is not supported.

See #25 
