### PR TITLE
ship inited sdk

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -83,23 +83,11 @@ jobs:
             --build-arg NORDIC_COMMAND_LINE_TOOLS_VERSION=${{ matrix.NORDIC_COMMAND_LINE_TOOLS_VERSION }} \
             .
 
-      - name: Initialize sdk-nrf
-        run: |
-          docker run --rm -v ${PWD}:/workdir/project \
-            nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} \
-              west init -m https://github.com/nrfconnect/sdk-nrf --mr ${{ matrix.ncs_branch }}
-
-      - name: Update west dependencies
-        run: |
-          docker run --rm -v ${PWD}:/workdir/project \
-            nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} \
-              west update --narrow -o=--depth=1
-
       - name: Build asset_tracker application
         if: matrix.asset_tracker != 'disable'
         run: |
-          docker run --rm -v ${PWD}:/workdir/project \
-            -w /workdir/project/nrf/applications/asset_tracker \
+          docker run --rm \
+            -w /workdir/nrf/applications/asset_tracker \
             nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} \
               west build -b nrf9160dk_nrf9160ns -- -DEXTRA_CFLAGS="${{ matrix.EXTRA_CFLAGS }}"
 
@@ -114,8 +102,8 @@ jobs:
       - name: Build asset_tracker_v2 application
         if: matrix.asset_tracker_v2 != 'disable'
         run: |
-          docker run --rm -v ${PWD}:/workdir/project \
-            -w /workdir/project/nrf/applications/asset_tracker_v2 \
+          docker run --rm \
+            -w /workdir/nrf/applications/asset_tracker_v2 \
             nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} \
               west build -b nrf9160dk_nrf9160ns -- -DEXTRA_CFLAGS="${{ matrix.EXTRA_CFLAGS }}"
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -79,23 +79,11 @@ jobs:
             --build-arg NORDIC_COMMAND_LINE_TOOLS_VERSION=${{ matrix.NORDIC_COMMAND_LINE_TOOLS_VERSION }} \
             .
 
-      - name: Initialize sdk-nrf
-        run: |
-          docker run --rm -v ${PWD}:/workdir/project \
-            nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} \
-              west init -m https://github.com/nrfconnect/sdk-nrf --mr ${{ matrix.ncs_branch }}
-
-      - name: Update west dependencies
-        run: |
-          docker run --rm -v ${PWD}:/workdir/project \
-            nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} \
-              west update --narrow -o=--depth=1
-
       - name: Build asset_tracker application
         if: matrix.asset_tracker != 'disable'
         run: |
-          docker run --rm -v ${PWD}:/workdir/project \
-            -w /workdir/project/nrf/applications/asset_tracker \
+          docker run --rm \
+            -w /workdir/nrf/applications/asset_tracker \
             nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} \
               west build -b nrf9160dk_nrf9160ns
 
@@ -110,8 +98,8 @@ jobs:
       - name: Build asset_tracker_v2 application
         if: matrix.asset_tracker_v2 != 'disable'
         run: |
-          docker run --rm -v ${PWD}:/workdir/project \
-            -w /workdir/project/nrf/applications/asset_tracker_v2 \
+          docker run --rm \
+            -w /workdir/nrf/applications/asset_tracker_v2 \
             nordicplayground/nrfconnect-sdk:${{ matrix.ncs_branch }} \
               west build -b nrf9160dk_nrf9160ns -- -DEXTRA_CFLAGS="${{ matrix.EXTRA_CFLAGS }}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ARG NRF_UTIL_VERSION=6.1.7
 ARG NORDIC_COMMAND_LINE_TOOLS_VERSION="Versions-10-x-x/10-17-0/nrf-command-line-tools-10.17.0"
 
 # System dependencies
-RUN mkdir /workdir/project && \
-    mkdir /workdir/.cache && \
+RUN mkdir /workdir/.cache && \
     apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y install \
@@ -116,7 +115,6 @@ RUN mkdir /workdir/project && \
 FROM base
 ARG sdk_nrf_revision=main
 RUN \
-    mkdir tmp && cd tmp && \
     west init -m https://github.com/nrfconnect/sdk-nrf --mr ${sdk_nrf_revision} && \
     west update --narrow -o=--depth=1 && \
     echo "Installing requirements: zephyr/scripts/requirements.txt" && \
@@ -135,14 +133,13 @@ RUN \
         ;; \
     esac && \
     echo "Installing requirements: bootloader/mcuboot/scripts/requirements.txt" && \
-    python3 -m pip install -r bootloader/mcuboot/scripts/requirements.txt && \
-    cd .. && rm -rf tmp
+    python3 -m pip install -r bootloader/mcuboot/scripts/requirements.txt
 
-WORKDIR /workdir/project
+WORKDIR /workdir
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV XDG_CACHE_HOME=/workdir/.cache
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 ENV ZEPHYR_SDK_INSTALL_DIR=/workdir/zephyr-sdk
-ENV ZEPHYR_BASE=/workdir/project/zephyr
+ENV ZEPHYR_BASE=/workdir/zephyr
 ENV PATH="${ZEPHYR_BASE}/scripts:${PATH}"

--- a/README.md
+++ b/README.md
@@ -57,52 +57,13 @@ docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main 
 
 The rest of the documentation will use the local name `nrfconnect-sdk`, but any of them can use `nordicplayground/nrfconnect-sdk:main` (or a different tag) instead.
 
-### Initialize and update west dependencies
-
-Setting up the nRF Connect SDK to build sample applications and a stand-alone repository is a bit different, so we'll demonstrate both.
-
-#### Using the nRF Connect SDK
-
-```bash
-mkdir nrfconnect && cd nrfconnect
-docker run --rm -v ${PWD}:/workdir/project nrfconnect-sdk /bin/bash -c '\
-    west init -m https://github.com/nrfconnect/sdk-nrf && \
-    west update --narrow -o=--depth=1'
-```
-
-#### Using it with an out-of-tree repository
-
-Because west installs the dependency repository in the parent-folder of the project folder we need to have an extra subfolder where the custom firmware code is located. Then the containing folder can be mounted when running the container and the output from west will be stored alongside the custom firmware folder. Here's an example folder layout for the `my-application`:
-
-    build-with-nrf-connect-sdk
-    ├── bootloader
-    ├── mbedtls
-    ├── modules
-    ├── my-application
-    ├── nrf
-    ├── nrfxlib
-    ├── test
-    ├── tools
-    └── zephyr
-
-Now we can initialize the image for use with our out-of-tree firmware folder:
-
-```bash
-mkdir build-with-nrf-connect-sdk && cd build-with-nrf-connect-sdk
-git clone https://github.com/my-org/my-application
-docker run --rm -v ${PWD}:/workdir/project nrfconnect-sdk /bin/bash -c '\
-    cd my-application && \
-    west init -l && \
-    west update --narrow -o=--depth=1'
-```
-
 ### Build the firmware
 
 To demonstrate, we'll build the _asset_tracker_v2_ application from sdk-nrf:
 
 ```bash
-docker run --rm -v ${PWD}:/workdir/project \
-    -w /workdir/project/nrf/applications/asset_tracker_v2 \
+docker run --rm \
+    -w /workdir/nrf/applications/asset_tracker_v2 \
     nrfconnect-sdk \
     west build -p always -b nrf9160dk_nrf9160_ns
 ```
@@ -111,12 +72,11 @@ The firmware file will be located here: `nrf/applications/asset_tracker_v2/build
 
 > ℹ️ The `-p always` build argument is to do a pristine build. It is similar to cleaning the build folder and is used because it is less error-prone to a previous build with different configuration. To speed up subsequent build with the same configuration you can remove this argument to avoid re-building code that haven't been modified since the previous build.
 
-To build a stand-alone project, replace `-w /workdir/project/nrf/applications/asset_tracker_v2` with the name of the applications folder inside the docker container:
+To build a stand-alone project, replace `-w /workdir/nrf/applications/asset_tracker_v2` with the name of the applications folder inside the docker container:
 
 ```bash
 # run from the build-with-nrf-connect-sdk
 docker run --rm -v ${PWD}:/workdir/project \
-    -w /workdir/project/my-application \
     nrfconnect-sdk \
     west build -p always -b nrf9160dk_nrf9160_ns
 ```
@@ -129,26 +89,14 @@ git clone https://github.com/NordicPlayground/nrf-docker
 cd nrf-docker
 docker build -t nrfconnect-sdk --build-arg sdk_nrf_revision=v2.1-branch .
 cd ..
-
-# initialize sdk-nrf and build asset_tracker_v2 application
-mkdir nrfconnect && cd nrfconnect
-docker run --rm -v ${PWD}:/workdir/project nrfconnect-sdk /bin/bash -c '\
-    west init -m https://github.com/nrfconnect/sdk-nrf --mr v2.1-branch && \
-    west update --narrow -o=--depth=1 && \
-    cd nrf/applications/asset_tracker_v2 && \
-    west build -p always -b nrf9160dk_nrf9160_ns'
-ls -la nrf/applications/asset_tracker_v2/build/zephyr/merged.hex
 ```
-
-> ℹ️ The `--mr` argument to `west init` specifies the manifest revision, which is the same as the SDK version. It can be a _branch_, _tag_ or a _sha_. It's recommended to select a recent stable version. Which will be tagged. See available [tags in the sdk-nrf repo](https://github.com/nrfconnect/sdk-nrf/tags).
 
 ### Build a Zephyr sample using the hosted image
 
 This builds the `hci_uart` sample and stores the `hci_uart.hex` file in the current directory:
 
 ```bash
-# assumes `west init` and `west update` from before
-docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main \
+docker run --rm nordicplayground/nrfconnect-sdk:main \
     west build zephyr/samples/bluetooth/hci_uart -p always -b nrf9160dk_nrf52840
 ls -la build/zephyr && cp build/zephyr/zephyr.hex ./hci_uart.hex
 ```
@@ -157,10 +105,8 @@ ls -la build/zephyr && cp build/zephyr/zephyr.hex ./hci_uart.hex
 
 ```bash
 # Init and build in Docker
-docker run --rm -v ${PWD}:/workdir/project nrfconnect-sdk /bin/bash -c '\
-    west init -m https://github.com/nrfconnect/sdk-nrf --mr v2.1-branch && \
-    west update --narrow -o=--depth=1 && \
-    west build zephyr/samples/bluetooth/peripheral_ht -p always -b nrf52840dk_nrf52840'
+docker run --rm nordicplayground/nrfconnect-sdk:main \
+  west build zephyr/samples/bluetooth/peripheral_ht -p always -b nrf52840dk_nrf52840
 
 # Access build files
 cp build/zephyr/zephyr.hex peripheral_ht.hex
@@ -173,8 +119,8 @@ ls -la ./peripheral_ht.hex
 
 ```bash
 # assumes asset_tracker_v2 built already (see above)
-docker run --rm -v ${PWD}:/workdir/project \
-    -w /workdir/project/nrf/applications/asset_tracker_v2 \
+docker run --rm \
+    -w /workdir/nrf/applications/asset_tracker_v2 \
     --device=/dev/ttyACM0 --privileged \
     nrfconnect-sdk \
     west flash
@@ -202,7 +148,6 @@ to format your sources.
 ## Interactive usage
 
 ```bash
-# from a folder you've initialized with west already
 docker run -it --name nrfconnect-sdk -v ${PWD}:/workdir/project \
     nrfconnect-sdk /bin/bash
 ```


### PR DESCRIPTION
- fix(zephry-sdk): do not install host tools on Mac OS
- feat: ship with initialized nRF Connect SDK
