### PR TITLE
`west init --mr SHA` works again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,8 +134,12 @@ RUN mkdir /workdir/.cache && \
 # Download sdk-nrf and west dependencies to install pip requirements
 FROM base
 ARG sdk_nrf_revision=main
+ARG sdk_nrf_commit
 RUN \
     west init -m https://github.com/nrfconnect/sdk-nrf --mr ${sdk_nrf_revision} && \
+    if [[ $sdk_nrf_commit =~ "^[a-fA-F0-9]{32}$" ]]; then \
+        git checkout ${sdk_nrf_revision} ; \
+    fi && \
     west update --narrow -o=--depth=1 && \
     echo "Installing requirements: zephyr/scripts/requirements.txt" && \
     python3 -m pip install -r zephyr/scripts/requirements.txt && \


### PR DESCRIPTION
`west init --mr SHA` does not work for a while now.

This PR adds this capability back into the resulting docker-image.

Relates to nrfconnect/sdk-nrf#11346