### PR TITLE
Add GitLab-CI Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ SHELL [ "/bin/bash", "-euxo", "pipefail", "-c" ]
 RUN <<EOT
     apt-get -y update
     apt-get -y upgrade
-    apt-get -y install wget unzip
+    apt-get -y install wget unzip curl
 EOT
 
 # Install toolchain

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ RUN <<EOT
     west update --narrow -o=--depth=1
 EOT
 
+# The ZEPHYR_BASE variable is not set by nrfutil
+ENV ZEPHYR_BASE=/workdir/zephyr
+
 # Launch into build environment with the passed arguments
 # Currently this is not supported in GitHub Actions
 # See https://github.com/actions/runner/issues/1964

--- a/entry.sh
+++ b/entry.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec $@
+exec "$@"


### PR DESCRIPTION
With these patches, the Docker image can be used directly in a GitLab CI pipeline.