### PR TITLE
Add libffi7 for python 3.8 support

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -82,6 +82,10 @@ jobs:
         run: |
           docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.sdk_nrf_branch }} west build -b ${{ matrix.native_board }} zephyr/samples/hello_world
 
+      - name: Ensure zephyr twister unit tests works
+        run: |
+          docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.sdk_nrf_branch }} west twister -p ${{ matrix.native_board }} -T zephyr/samples/subsys/testsuite/integration
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Ensure zephyr twister unit tests works
         run: |
-          docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.sdk_nrf_branch }} west twister -p ${{ matrix.native_board }} -T zephyr/samples/subsys/testsuite/integration
+          docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.sdk_nrf_branch }} ./zephyr/scripts/twister -p ${{ matrix.native_board }} -T zephyr/samples/subsys/testsuite/integration
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -78,4 +78,4 @@ jobs:
 
       - name: Ensure zephyr twister unit tests works
         run: |
-          docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.sdk_nrf_branch }} west twister -p ${{ matrix.native_board }} -T zephyr/samples/subsys/testsuite/integration
+          docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.sdk_nrf_branch }} ./zephyr/scripts/twister -p ${{ matrix.native_board }} -T zephyr/samples/subsys/testsuite/integration

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -75,3 +75,7 @@ jobs:
       - name: Ensure native build works
         run: |
           docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.sdk_nrf_branch }} west build -b ${{ matrix.native_board }} zephyr/samples/hello_world
+
+      - name: Ensure zephyr twister unit tests works
+        run: |
+          docker run --rm nordicplayground/nrfconnect-sdk:${{ matrix.sdk_nrf_branch }} west twister -p ${{ matrix.native_board }} -T zephyr/samples/subsys/testsuite/integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,13 @@ RUN <<EOT
     apt-get -y install gcc-multilib make
 EOT
 
+#
+# python 3.8 is installed by toolchain manager hence older version of libffi is required
+#
+RUN <<EOT
+    apt-get -y install libffi7
+EOT
+
 # Nordic command line tools
 # Releases: https://www.nordicsemi.com/Products/Development-tools/nrf-command-line-tools/download
 RUN <<EOT


### PR DESCRIPTION
The zephyr test runner [twister](https://docs.zephyrproject.org/latest/develop/test/twister.html) fails because the ctypes dependency requires libffi7 when using python 3.8 (the version of python installed by the toolchain manager).