### PR TITLE
Clean up image to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL [ "/bin/bash", "-euxo", "pipefail", "-c" ]
 
+# gcc-multilib make = Host tools for native_sim build
+# python 3.8 is installed by toolchain manager hence older version of libffi is required
 RUN <<EOT
     apt-get -y update
     apt-get -y upgrade
-    apt-get -y install wget unzip
+    apt-get -y install wget unzip clang-format gcc-multilib make libffi7
+    apt-get -y clean
+    rm -rf /var/lib/apt/lists/*
 EOT
 
 # Install toolchain
@@ -37,22 +41,7 @@ EOT
 # ClangFormat
 #
 RUN <<EOT
-    apt-get -y install clang-format
     wget -qO- https://raw.githubusercontent.com/nrfconnect/sdk-nrf/${sdk_nrf_branch}/.clang-format > /workdir/.clang-format
-EOT
-
-#
-# Host tools for native_sim build
-#
-RUN <<EOT
-    apt-get -y install gcc-multilib make
-EOT
-
-#
-# python 3.8 is installed by toolchain manager hence older version of libffi is required
-#
-RUN <<EOT
-    apt-get -y install libffi7
 EOT
 
 # Nordic command line tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN <<EOT
     nrfutil install toolchain-manager search
     nrfutil toolchain-manager install --ncs-version ${toolchain_version}
     nrfutil toolchain-manager list
+    rm -f /root/ncs/downloads/*
 EOT
 
 #


### PR DESCRIPTION
As per #93 :

- Remove APT package cache and package lists
- Put all apt installs in one place (Docker best practices, also can't do no. 1 without it)
- Remove .tar.gz archive of downloaded toolchain